### PR TITLE
Bugfix for issue #25

### DIFF
--- a/content.js
+++ b/content.js
@@ -963,7 +963,7 @@ var zhongwenContent = {
                     hanziClass += '-small';
                 }
                 var hanziSpan = document.createElement('span');
-                hanziSpan.textContent = e[2];
+                hanziSpan.textContent = word;
                 hanziSpan.className = hanziClass;
                 fragment.appendChild(hanziSpan);
 


### PR DESCRIPTION
The file was incorrectly merged from Chrome version 4.21. As a result, the Firefox version would always show simplified characters, no matter if 'auto' was chosen or not (see discussion regarding issue #25).